### PR TITLE
test: add `composer`

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ then, add the overlay to your Nixpkgs instance. `outputs`, you will be able to a
 This is a function that, for given source, returns a derivation with a Composer repository containing the packages listed by the Composer lock file in the source directory. It takes the following arguments:
 
 - Either `lockFile` containing an explicit path to `composer.lock` file, or `src`, which is the source directory/derivation containing the file.
-- `includeDev` – optional boolean variable controlling whether developer dependencies should be installed. Defaults to `true`.
 
 ### `c4.composerSetupHook`
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -x -o errexit
 
+nix build -L --no-write-lock-file ./tests#composer
 nix build -L --no-write-lock-file ./tests#grav
 nix build -L --no-write-lock-file ./tests#non-head-rev

--- a/src/composer-setup-hook.sh
+++ b/src/composer-setup-hook.sh
@@ -20,7 +20,7 @@ composerSetupPreConfigureHook() {
     composer config repo.c4 '{"type": "composer", "url": "file://'"$composerDeps"'"}'
 
     # Synchronize the lock file with the config changes.
-    composer --no-ansi update --lock
+    composer --no-ansi update --lock --no-install
 
     if [[ -n $composerRoot ]]; then
         popd

--- a/src/fetch-deps.nix
+++ b/src/fetch-deps.nix
@@ -7,7 +7,6 @@
 {
   src ? null,
   lockFile ? null,
-  includeDev ? true,
 }:
 
 assert lib.assertMsg ((src == null) != (lockFile == null)) "Either “src” or “lockFile” attribute needs to be provided.";
@@ -23,7 +22,8 @@ let
 
   lock = lib.importJSON (if lockFile != null then lockFile else "${src}/composer.lock");
 
-  packagesToInstall = lock.packages ++ lib.optionals includeDev lock.packages-dev;
+  # We always need to fetch dev dependencies so that `composer update --lock` can update the config.
+  packagesToInstall = lock.packages ++ lock.packages-dev;
 
   sources = builtins.map (pkg: { inherit (pkg) name version; source = fetchComposerPackage pkg; }) packagesToInstall;
 

--- a/tests/composer/default.nix
+++ b/tests/composer/default.nix
@@ -1,0 +1,48 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  php,
+  c4,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "composer";
+  version = "2.5.5";
+
+  src = fetchFromGitHub {
+    owner = "composer";
+    repo = "composer";
+    rev = version;
+    sha256 = "sha256-eOZVJFa0GViO/jcFIonhJxAHD2DdpLOOmOPtqGMMl2w=";
+  };
+
+  composerDeps = c4.fetchComposerDeps {
+    inherit src;
+  };
+
+  nativeBuildInputs = [
+    php.packages.composer
+    c4.composerSetupHook
+  ];
+
+  installCheckInputs = [
+    php
+  ];
+
+  doInstallCheck = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    composer --no-ansi install --no-dev
+    cp -r . $out
+
+    runHook postInstall
+  '';
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    runHook postInstallCheck
+  '';
+}

--- a/tests/flake.nix
+++ b/tests/flake.nix
@@ -14,6 +14,7 @@
       };
     in
     {
+      packages.x86_64-linux.composer = pkgs.callPackage ./composer { };
       packages.x86_64-linux.grav = pkgs.callPackage ./grav { };
       packages.x86_64-linux.non-head-rev = pkgs.callPackage ./non-head-rev { };
     };


### PR DESCRIPTION
This PR has been initiated to highlight a problem I've encountered while working on the temporary branch available here: https://github.com/NixOS/nixpkgs/pull/232450.

The core issue is my inability to build `composer`, which has effectively stalled my progress since `composer` is required in any PHP derivation. I can reproduce the issue with [`drupol/composer-local-repo-plugin`](https://github.com/drupol/composer-local-repo-plugin/) since they are producing the same outputs.

Here's how you can replicate the issue:

1. Navigate to the tests directory: `cd tests`
2. Run the build command: `nix build .#composer -L`

![image](https://github.com/fossar/composition-c4/assets/252042/eafeb695-b738-4215-a1bd-d0d95efa8a65)

A thorough review of the logs will clarify the problem.
Composer is attempting to retrieve a package following a four-part version pattern (`Root composer.json requires phpstan/phpstan == 1.10.7.0, found phpstan/phpstan[1.10.7] in the lock file but not in remote repositories, make sure you avoid updating this package to keep the one from the lock file.`). See the versions there `1.10.7.0 !=  1.10.7` !
However, during the construction of the `packages.json` file, no four-part version pattern is available – only three-part versions are present.
This discrepancy is leading me to suspect a potential bug in `composer`.
The creation of this PR is largely driven by this suspicion.

After a little investigation, I notice that four-part version pattern is the normalized version, see it here:

![image](https://github.com/fossar/composition-c4/assets/252042/bc16360b-9a60-41a4-aad8-de33a53d89df)

Is it possible to access this value with the composer api ? Yes! With `$package->getVersion()`.