### PR TITLE
BREAKING(fetchComposerDeps): Remove `includeDev` argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ then, add the overlay to your Nixpkgs instance. `outputs`, you will be able to a
 This is a function that, for given source, returns a derivation with a Composer repository containing the packages listed by the Composer lock file in the source directory. It takes the following arguments:
 
 - Either `lockFile` containing an explicit path to `composer.lock` file, or `src`, which is the source directory/derivation containing the file.
-- `includeDev` – optional boolean variable controlling whether developer dependencies should be installed. Defaults to `true`.
 
 ### `c4.composerSetupHook`
 

--- a/src/composer-setup-hook.sh
+++ b/src/composer-setup-hook.sh
@@ -20,7 +20,7 @@ composerSetupPreConfigureHook() {
     composer config repo.c4 '{"type": "composer", "url": "file://'"$composerDeps"'"}'
 
     # Synchronize the lock file with the config changes.
-    composer --no-ansi update --lock
+    composer --no-ansi update --lock --no-install
 
     if [[ -n $composerRoot ]]; then
         popd

--- a/src/fetch-deps.nix
+++ b/src/fetch-deps.nix
@@ -7,7 +7,6 @@
 {
   src ? null,
   lockFile ? null,
-  includeDev ? true,
 }:
 
 assert lib.assertMsg ((src == null) != (lockFile == null)) "Either “src” or “lockFile” attribute needs to be provided.";
@@ -23,7 +22,8 @@ let
 
   lock = lib.importJSON (if lockFile != null then lockFile else "${src}/composer.lock");
 
-  packagesToInstall = lock.packages ++ lib.optionals includeDev lock.packages-dev;
+  # We always need to fetch dev dependencies so that `composer update --lock` can update the config.
+  packagesToInstall = lock.packages ++ lock.packages-dev;
 
   sources = builtins.map (pkg: { inherit (pkg) name version; source = fetchComposerPackage pkg; }) packagesToInstall;
 


### PR DESCRIPTION
`composer update --lock` will still need to update the dev dependencies in the lock file, even if we were to pass it `--no-dev`.
