### PR TITLE
test: add example project with local repository path

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -4,3 +4,4 @@ set -x -o errexit
 nix build -L --no-write-lock-file ./tests#composer
 nix build -L --no-write-lock-file ./tests#grav
 nix build -L --no-write-lock-file ./tests#non-head-rev
+nix build -L --no-write-lock-file ./tests#inner-outer-repo

--- a/tests/flake.nix
+++ b/tests/flake.nix
@@ -17,5 +17,6 @@
       packages.x86_64-linux.composer = pkgs.callPackage ./composer { };
       packages.x86_64-linux.grav = pkgs.callPackage ./grav { };
       packages.x86_64-linux.non-head-rev = pkgs.callPackage ./non-head-rev { };
+      packages.x86_64-linux.inner-outer-repo = pkgs.callPackage ./inner-outer-repo { };
     };
 }

--- a/tests/inner-outer-repo/a/b/composer.json
+++ b/tests/inner-outer-repo/a/b/composer.json
@@ -1,0 +1,6 @@
+{
+    "name": "inner/repo",
+    "homepage": "https://example.com/",
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/tests/inner-outer-repo/composer.json
+++ b/tests/inner-outer-repo/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "outer/repo",
+    "homepage": "https://example.com/",
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "require": {
+        "inner/repo": "*"
+    },
+    "repositories": {
+        "inner": {
+            "type": "path",
+            "url": "a/b"
+        }
+    }
+}

--- a/tests/inner-outer-repo/composer.lock
+++ b/tests/inner-outer-repo/composer.lock
@@ -1,0 +1,33 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "13f69a3281f4672868fcb8d3d5807bf3",
+    "packages": [
+        {
+            "name": "inner/repo",
+            "version": "dev-main",
+            "dist": {
+                "type": "path",
+                "url": "a/b",
+                "reference": "2a9bd6acb725e416b41393269f18c60ebb12fa6e"
+            },
+            "type": "library",
+            "homepage": "https://example.com/",
+            "transport-options": {
+                "relative": true
+            }
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "dev",
+    "stability-flags": [],
+    "prefer-stable": true,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.3.0"
+}

--- a/tests/inner-outer-repo/default.nix
+++ b/tests/inner-outer-repo/default.nix
@@ -1,0 +1,45 @@
+{
+  stdenv,
+  fetchFromGitHub,
+  php,
+  c4,
+}:
+
+stdenv.mkDerivation rec {
+  pname = "test/inner-oute-repo";
+  version = "1.0.0";
+
+  src = ./.;
+
+  composerDeps = c4.fetchComposerDeps {
+    lockFile = ./composer.lock;
+  };
+
+  nativeBuildInputs = [
+    php.packages.composer
+    c4.composerSetupHook
+  ];
+
+  installCheckInputs = [
+    php
+  ];
+
+  doInstallCheck = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    composer --no-ansi install --no-dev
+    cp -r . $out
+
+    runHook postInstall
+  '';
+
+  installCheckPhase = ''
+    runHook preInstallCheck
+
+    ls -la
+
+    runHook postInstallCheck
+  '';
+}


### PR DESCRIPTION
Hello,

While working on https://github.com/NixOS/nixpkgs/pull/232450, I was trying to test the new builder with a PHP project containing repositories of type `path`.

Using such project does not work with `fossar/composition-c4` yet because only dependencies containing `source` attribute are allowed. A dependency bounded to a local path repository does not have a `source` attribute, only a `dist` attribute.

Since Composer is able to work with these kind of repositories, we must ensure `fossar/composition-c4` can do it as well  (see relevant part of the code https://github.com/composer/composer/blob/main/src/Composer/Downloader/DownloadManager.php#L143).

I added a new test `inner-outer-repo` test that highlight the issue.

I can't reproduce the issue in [`drupol/composer-local-repo-plugin`](https://github.com/drupol/composer-local-repo-plugin/) since the download of these dependencies is done through Composer which is already doing those checks and react accordingly.